### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 arc-theme (20190917+git20200328-3) UNRELEASED; urgency=medium
 
   * Set field Upstream-Contact in debian/copyright.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:18:20 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ arc-theme (20190917+git20200328-3) UNRELEASED; urgency=medium
 
   * Set field Upstream-Contact in debian/copyright.
   * Use canonical URL in Vcs-Git.
+  * Remove obsolete fields Contact, Name from debian/upstream/metadata
+    (already present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:18:20 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+arc-theme (20190917+git20200328-3) UNRELEASED; urgency=medium
+
+  * Set field Upstream-Contact in debian/copyright.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:18:20 +0000
+
 arc-theme (20190917+git20200328-2) unstable; urgency=medium
 
   * Transition for GNOME 3.36

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper (>= 12),
 Standards-Version: 4.5.0
 Homepage: https://github.com/jnsh/arc-theme
 Vcs-Browser: https://github.com/UbuntuBudgie/arc-theme/tree/debian
-Vcs-Git: https://github.com/UbuntuBudgie/arc-theme -b debian
+Vcs-Git: https://github.com/UbuntuBudgie/arc-theme.git -b debian
 
 Package: arc-theme
 Architecture: all

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: arc-theme
 Source: https://github.com/jnsh/arc-theme
+Upstream-Contact: Joonas Henriksson <joonas.henriksson@gmail.com>
 
 Files: *
 Copyright: 2016-2017, horst3180 <email address hidden>

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,7 +1,5 @@
 ---
-Name: arc-theme
 Bug-Database: https://github.com/jnsh/arc-theme
-Contact: Joonas Henriksson <joonas.henriksson@gmail.com>
 Repository: https://github.com/jnsh/arc-theme.git
 Repository-Browse: https://github.com/jnsh/arc-theme
 Screenshots: https://horst3180.deviantart.com/art/20150518-533907665


### PR DESCRIPTION
Fix some issues reported by lintian
* Set field Upstream-Contact in debian/copyright.
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))
* Remove obsolete fields Contact, Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/arc-theme/aae8f8ec-c286-4ce0-b942-5456dd88d152.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/aae8f8ec-c286-4ce0-b942-5456dd88d152/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/aae8f8ec-c286-4ce0-b942-5456dd88d152/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/aae8f8ec-c286-4ce0-b942-5456dd88d152/diffoscope)).
