### PR TITLE
remove unnecessary dependencies from arc-theme

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,10 +19,7 @@ Vcs-Git: https://github.com/UbuntuBudgie/arc-theme.git -b debian
 
 Package: arc-theme
 Architecture: all
-Depends: gnome-themes-extra,
- gtk2-engines-murrine,
- gtk2-engines-pixbuf,
- ${misc:Depends}
+Depends: ${misc:Depends}
 Description: Flat theme with transparent elements
  Arc is a flat theme with transparent elements for GTK+4, GTK+ 3,
  GTK+ 2 and GNOME Shell which supports GTK+ 3 and GTK+ 2 based


### PR DESCRIPTION
Dependencies on gnome-themes-extra, gtk2-engines-murrine, gtk2-engines-pixbuf.